### PR TITLE
Fix wrong macro for boolean to value conversion

### DIFF
--- a/src/bindings/blst_bindings_stubs.c
+++ b/src/bindings/blst_bindings_stubs.c
@@ -414,7 +414,7 @@ CAMLprim value caml_blst_fp12_in_group_stubs(value x) {
   CAMLparam1(x);
   blst_fp12 *x_c = Blst_fp12_val(x);
   bool r = blst_fp12_in_group(x_c);
-  CAMLreturn(Bool_val(r));
+  CAMLreturn(Val_bool(r));
 }
 
 static struct custom_operations blst_p1_ops = {"blst_p1",


### PR DESCRIPTION
This caused the function to always return a raw `0`, which is neither `true` nor `false` so could be interpreted either way by the OCaml code.