### PR TITLE
Fix: update rule ./src/blst.js dependencies

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -45,6 +45,7 @@
  (deps
   (source_tree libblst)
   needed-wasm-names
+  bindings/blst_extended.c
   (glob_files *.h))
  (targets blst.wasm blst.js)
  (action


### PR DESCRIPTION
Context: At the moment, in isolated build environments, `dune build ./src/blst.js` fails because of missing
`bindings/blst_extended.c` in the build tree. This was probably not caught because `src/blst.js` (or wasm) was probably always run after running the main installable targets